### PR TITLE
Adds magic line to install script.

### DIFF
--- a/install
+++ b/install
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 sudo apt-get install git codeblocks codeblocks-contrib
 
 if [ ! -e dependencies ]; then


### PR DESCRIPTION
Makes install script directly callable by other shells, like fish or zsh.